### PR TITLE
Remove uses of Function prototype extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Uni-Form
 import Ember from 'ember';
 export default Ember.Controller.extend({
 
-  myForm: function () {
+  myForm: Ember.computed('model', function () {
     return this.store.createRecord('uni-form', { payload: this.get('model') });
-  }.property('model'),
+  }),
 
   actions: {
     mySubmit: function () {

--- a/addon/components/uni-form-radio.js
+++ b/addon/components/uni-form-radio.js
@@ -18,8 +18,8 @@ export default Ember.Component.extend(
   label: '',
   value: '',
 
-  checked: function () {
+  checked: Ember.computed('value', 'groupValue', 'field.dynamicAliasReady', function () {
     return this.get('value') === this.get('groupValue');
-  }.property('value', 'groupValue', 'field.dynamicAliasReady'),
+  }),
 
 });

--- a/addon/components/uni-form-select-tag.js
+++ b/addon/components/uni-form-select-tag.js
@@ -15,14 +15,14 @@ export default Ember.Component.extend({
     if (this.$()) this.set('value', this.$().val());
   },
 
-  _content: function () {
+  _content: Ember.computed('content', 'value', function () {
     return Ember.makeArray(this.get('content')).map(o => {
       return { label: o.label, selected: o.value === this.get('value'), value: o.value };
     });
-  }.property('content', 'value'),
+  }),
 
-  valueChange: function () {
+  valueChange: Ember.observer('value', function () {
     Ember.run.next(() => { if (this.$()) this.$().val(this.get('value')); });
-  }.observes('value'),
+  }),
 
 });

--- a/addon/mixins/debounces-input-value.js
+++ b/addon/mixins/debounces-input-value.js
@@ -8,17 +8,17 @@ export default Ember.Mixin.create(
   debouncedProperties: [ 'inputValue' ],
   inputValueDelay: 100,
 
-  debouncedInputValueChanged: function () {
+  debouncedInputValueChanged: Ember.observer('debouncedInputValue', function () {
     this.set('value', this.get('debouncedInputValue'));
-  }.observes('debouncedInputValue'),
+  }),
 
   focusOut: function () {
     this._super(...arguments);
     this.set('value', this.get('inputValue'));
   },
 
-  valueChanged: function () {
+  valueChanged: Ember.observer('value', function () {
     this.set('inputValue', this.get('value'));
-  }.observes('value'),
+  }),
 
 });

--- a/addon/mixins/finds-field-by-name.js
+++ b/addon/mixins/finds-field-by-name.js
@@ -5,13 +5,13 @@ export default Ember.Mixin.create(
   FindsParentFormView,
 {
 
-  field: function () {
+  field: Ember.computed('form', 'payloadKey', function () {
     var form = this.get('form');
     var name = (this.get('payloadKey') || '').replace(/\./g, '_');
     var path = `fieldsByName.${name}`;
     if (!form || !name) return {};
     return form.get(path) || {};
-  }.property('form', 'payloadKey'),
+  }),
 
   form: Ember.computed.reads('parentFormView.form'),
 

--- a/addon/mixins/finds-parent-form-view.js
+++ b/addon/mixins/finds-parent-form-view.js
@@ -4,11 +4,11 @@ import Ember from 'ember';
 //
 export default Ember.Mixin.create({
 
-  parentFormView: function () {
+  parentFormView: Ember.computed('parentView', function () {
     var parentView = this;
     while (parentView = parentView.get('parentView')) {
       if (parentView.get('tagName') === 'form') return parentView;
     }
-  }.property('parentView'),
+  }),
 
 });

--- a/addon/mixins/has-field-status.js
+++ b/addon/mixins/has-field-status.js
@@ -23,57 +23,61 @@ export default Ember.Mixin.create(
     if (this.get('editing')) this.set('editing', false);
   },
 
-  initNodeValue: function () {
+  initNodeValue: Ember.on('didInsertElement', function () {
     Ember.run.next(() => {
       var nodes = this.$('input, select, textarea');
       if (!nodes) return;
       nodes.not('[type="radio"]')
       .val(this.get('value')).trigger('change');
     });
-  }.on('didInsertElement').observes('field.dynamicAliasReady'),
+  }),
 
-  label: function () {
+  initNodeValueObserver: Ember.observer('field.dynamicAliasReady', function () {
+    this.initNodeValue();
+  }),
+
+  label: Ember.computed('payloadKey', function () {
     return (this.get('payloadKey') || '').split('.').slice(-1)[0].dasherize().replace(/-/g, ' ').capitalize();
-  }.property('payloadKey'),
+  }),
 
-  maxlength: function () {
+  maxlength: Ember.computed('field.maxlength', 'field.dynamicAliasReady', function () {
     return this.get('field.maxlength');
-  }.property('field.maxlength', 'field.dynamicAliasReady'),
+  }),
 
-  message: function () {
+  message: Ember.computed('showStatus', 'field.message', function () {
     return this.get('showStatus') && this.get('field.message');
-  }.property('showStatus', 'field.message'),
+  }),
 
   name: Ember.computed.reads('payloadKey'),
 
-  optional: function () {
+  optional: Ember.computed('field.optional', 'field.dynamicAliasReady', function () {
     return this.get('field.optional');
-  }.property('field.optional', 'field.dynamicAliasReady'),
+  }),
 
   prompt: Ember.computed.reads('label'),
 
-  prompting: function () {
+  prompting: Ember.computed('value', 'field.dynamicAliasReady', function () {
     var value = this.get('value');
     return typeof value !== 'string' || value === PROMPT_VALUE;
-  }.property('value', 'field.dynamicAliasReady'),
+  }),
 
-  required: function () {
+  required: Ember.computed('field.required', 'field.dynamicAliasReady', function () {
     return this.get('field.required');
-  }.property('field.required', 'field.dynamicAliasReady'),
+  }),
 
-  showStatus: function () {
+  showStatus: Ember.computed('editing', 'parentFormView.submitFailed', function () {
     return this.get('parentFormView.submitFailed') || this.get('editing') === false;
-  }.property('editing', 'parentFormView.submitFailed'),
+  }),
 
-  status: function () {
+  status: Ember.computed('showStatus', 'tone', function () {
     return this.get('showStatus') && this.get('tone') || 'default';
-  }.property('showStatus', 'tone'),
+  }),
 
   value: Ember.computed.alias('field.value'),
 
-  valueChange: function () {
+  valueChange: Ember.observer('value', 'groupValue', function () {
     if (this._hasValueChanged() && this.$(':focus')) this.set('editing', true);
-  }.observes('value', 'groupValue'),
+  }),
 
   //
   // Helpers

--- a/addon/mixins/triggers-change.js
+++ b/addon/mixins/triggers-change.js
@@ -8,7 +8,7 @@ export default Ember.Mixin.create({
 
   changeTriggerInterval: 2500,
 
-  triggerChange: function () {
+  triggerChange: Ember.on('didInsertElement', function () {
 
     // Recursion.
     Ember.run.later(this, function () {
@@ -18,6 +18,6 @@ export default Ember.Mixin.create({
       this.triggerChange();
     }, this.get('changeTriggerInterval'));
 
-  }.on('didInsertElement')
+  })
 
 });

--- a/addon/models/uni-form-field.js
+++ b/addon/models/uni-form-field.js
@@ -9,27 +9,27 @@ export default DS.Model.extend({
   form: DS.belongsTo('uni-form', { inverse: null }),
 
   // i.e. "firstName"
-  basename: function () {
+  basename: Ember.computed('payloadKey', function () {
     return (this.get('payloadKey') || '').split('.').pop();
-  }.property('payloadKey'),
+  }),
 
   // i.e. "billingAddress_firstName" for payload.billingAddress.firstName
-  payloadKey: function () {
+  payloadKey: Ember.computed('name', function () {
     return (this.get('name') || '').replace(/_/g, '.');
-  }.property('name'),
+  }),
 
   // i.e. "" or "billingAddress"
-  parentKey: function () {
+  parentKey: Ember.computed('payloadKey', function () {
     var key = this.get('payloadKey');
     var lastDot = key.lastIndexOf('.');
     return lastDot === -1 ? '' : `${key.slice(0, lastDot)}`;
-  }.property('payloadKey'),
+  }),
 
   // i.e. "payload" or "payload.billingAddress"
-  parentPath: function () {
+  parentPath: Ember.computed('parentPath', function () {
     var parentKey = this.get('parentKey');
     return parentKey ? `payload.${parentKey}` : 'payload';
-  }.property('parentPath'),
+  }),
 
   //
   // Events

--- a/addon/models/uni-form.js
+++ b/addon/models/uni-form.js
@@ -5,7 +5,8 @@ import pathify from 'ember-uni-form/utils/pathify';
 
 export default DS.Model.extend({
 
-  messages: (() => []).property(),
+  messages: Ember.computed(() => []),
+
   payload: DS.attr(),
 
   // Set by component:uni-form.submit when validation fails
@@ -18,7 +19,7 @@ export default DS.Model.extend({
 
   fieldNames: Ember.computed.map('payloadKeys', name => name.replace(/\./g, '_')),
 
-  fieldsByName: function () {
+  fieldsByName: Ember.computed('payload', function () {
     var result = {};
     this.get('fieldNames').map(name => {
       result[name] = this.store.createRecord('uni-form-field', {
@@ -27,18 +28,18 @@ export default DS.Model.extend({
       });
     });
     return result;
-  }.property('payload'),
+  }),
 
-  payloadKeys: function () {
+  payloadKeys: Ember.computed('payload', function () {
     if (!this.get('payload')) return [];
     return pathify(this.get('payload'), this.get('store'));
-  }.property('payload'),
+  }),
 
   //
   // Observers
   //
 
-  watchClientErrors: function () {
+  watchClientErrors: Ember.observer('payload', function () {
     this.get('payloadKeys').forEach(payloadKey => {
       var lastDot = payloadKey.lastIndexOf('.');
       var basename = payloadKey.slice(lastDot + 1);
@@ -52,7 +53,7 @@ export default DS.Model.extend({
       this.addObserver(errorsPath, this, syncErrors);
       syncErrors();
     });
-  }.observes('payload'),
+  }),
 
   //
   // Methods

--- a/tests/dummy/app/components/uni-form-select-month.js
+++ b/tests/dummy/app/components/uni-form-select-month.js
@@ -1,12 +1,13 @@
+import Ember from 'ember';
 import UniFormSelectComponent from 'ember-uni-form/components/uni-form-select';
 
 export default UniFormSelectComponent.extend({
 
   prompt: 'Month',
 
-  content: function () {
+  content: Ember.computed(function () {
     return [ '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12' ]
     .map((s) => ({ label: s, value: s }));
-  }.property()
+  })
 
 });

--- a/tests/dummy/app/components/uni-form-select-year.js
+++ b/tests/dummy/app/components/uni-form-select-year.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import UniFormSelectComponent from 'ember-uni-form/components/uni-form-select';
 
 var NUM_YEARS = 13;
@@ -6,7 +7,7 @@ export default UniFormSelectComponent.extend({
 
   prompt: 'Year',
 
-  content: function () {
+  content: Ember.computed(function () {
     var year = new Date().getFullYear();
     var options = [];
     for (var i = 0; i < NUM_YEARS; i++) {
@@ -14,6 +15,6 @@ export default UniFormSelectComponent.extend({
       options.push({ label: s, value: s });
     }
     return options;
-  }.property()
+  })
 
 });

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -2,11 +2,11 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
 
-  uniForm: function () {
+  uniForm: Ember.computed('model', function () {
     var form = this.store.createRecord('uni-form', { payload: this.get('model') });
     window.form = form;
     return form;
-  }.property('model'),
+  }),
 
   dish: 'eggs',
   isDishabled: false,

--- a/tests/dummy/app/controllers/payment-method.js
+++ b/tests/dummy/app/controllers/payment-method.js
@@ -2,11 +2,11 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
 
-  uniForm: function () {
+  uniForm: Ember.computed('model', function () {
     var form = this.store.createRecord('uni-form', { payload: this.get('model') });
     window.form = form;
     return form;
-  }.property('model'),
+  }),
 
   actions: {
 

--- a/tests/dummy/app/models/address.js
+++ b/tests/dummy/app/models/address.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import DS from 'ember-data';
 import EmberValidations from 'ember-validations';
 
@@ -21,9 +22,9 @@ export default DS.Model.extend(
     { label: 'Other', value: 'other' },
   ],
 
-  addressString: function () {
+  addressString: Ember.computed('addressLine1', 'addressLine2', 'city', 'state', 'zipCode', function () {
     return `${this.get('addressLine1')} ${this.get('addressLine2')} ${this.get('city')}, ${this.get('state')} ${this.get('zipCode')}`;
-  }.property('addressLine1', 'addressLine2', 'city', 'state', 'zipCode'),
+  }),
 
   validations: {
     addressLine1: {

--- a/tests/dummy/app/models/payment-method.js
+++ b/tests/dummy/app/models/payment-method.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import DS from 'ember-data';
 import EmberValidations from 'ember-validations';
 
@@ -41,12 +42,12 @@ export default DS.Model.extend(
     }
   },
 
-  monthOptions: function () {
+  monthOptions: Ember.computed(function () {
     return [ '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12' ]
     .map(s => ({ label: s, value: s }));
-  }.property(),
+  }),
 
-  yearOptions: function () {
+  yearOptions: Ember.computed(function () {
     var year = new Date().getFullYear();
     var options = [];
     for (var i = 0; i < NUM_YEAR_OPTIONS; i++) {
@@ -54,6 +55,6 @@ export default DS.Model.extend(
       options.push({ label: s, value: s });
     }
     return options;
-  }.property(),
+  }),
 
 });


### PR DESCRIPTION
The only non-mechanical change was refactoring

```
initNodeValue: function () {
  Ember.run.next(() => {
    var nodes = this.$('input, select, textarea');
    if (!nodes) return;
    nodes.not('[type="radio"]')
    .val(this.get('value')).trigger('change');
  });
}.on('didInsertElement').observes('field.dynamicAliasReady'),
```

I separated out the listener and the observer into separate properties (figured this was the most readable option), though it's probably fine to combine them if desired.
