### PR TITLE
ember-validations@v2.2.0-dsc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ember-cli-babel": "^5.1.3",
     "ember-cli-htmlbars": "0.7.9",
     "ember-debounced-properties": "0.0.5",
-    "ember-validations": "git://github.com/dollarshaveclub/ember-validations.git#d1b7321"
+    "ember-validations": "git://github.com/dollarshaveclub/ember-validations.git#v2.2.0-dsc.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Updates DSC fork of ember-validations and fixes deprecation warnings about `this.get('container')`, deprecated in favor of `getOwner`.
