### PR TITLE
Fix acceptance test compatibility

### DIFF
--- a/addon/mixins/triggers-change.js
+++ b/addon/mixins/triggers-change.js
@@ -3,14 +3,15 @@ import Ember from 'ember';
 // Used to fix issues with autocomplete on various browsers.
 //
 
-
 export default Ember.Mixin.create({
 
   changeTriggerInterval: 2500,
 
-  triggerChange: Ember.on('didInsertElement', function () {
+  triggerChange: Ember.on('didInsertElement', function triggerChange() {
+    if (Ember.Test && !Ember.get(this, 'triggerUnderTest')) return;
+
     // Recursion.
-    Ember.run.later(this, function () {
+    Ember.run.later(() => {
       const $el = this.$();
       if (this.get('isDestroyed') || $el.length === 0) return;
       if ($el.trigger) $el.trigger('change');
@@ -18,4 +19,5 @@ export default Ember.Mixin.create({
     }, this.get('changeTriggerInterval'));
   }),
 
+  triggerUnderTest: false,
 });

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-data": "2.10.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
+    "ember-load-initializers": "0.6.3",
     "ember-resolver": "^2.0.3",
     "ember-try": "0.2.8",
     "eslint": "^3.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-uni-form",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Powerful forms, cleanly built.",
   "directories": {
     "doc": "doc",

--- a/tests/acceptance/payment-method-test.js
+++ b/tests/acceptance/payment-method-test.js
@@ -1,0 +1,12 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('acceptance:uniform');
+
+test('visiting /payment-method', function(assert) {
+  visit('/payment-method');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/payment-method', 'it should not break acceptance tests');
+  });
+});

--- a/tests/integration/components/triggers-change-test.js
+++ b/tests/integration/components/triggers-change-test.js
@@ -3,13 +3,13 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('triggers-change', {
-  integration: true
+  integration: true,
 });
 
-test('it should trigger DOM node change event on didInsertElement', function (assert) {
-  var done = assert.async();
+test('it should trigger DOM node change event on didInsertElement', function testTrigger(assert) {
+  const done = assert.async();
   this.set('x', 'initial');
-  this.render(hbs`{{ triggers-change changeTriggerInterval=1 }}`);
+  this.render(hbs`{{ triggers-change changeTriggerInterval=1 triggerUnderTest=true }}`);
   this.$('.triggers-change').on('change', () => this.set('x', 'updated via change event on DOM node'));
   Ember.run.later(() => {
     assert.equal(this.get('x'), 'updated via change event on DOM node');

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -2,5 +2,8 @@ import resolver from './helpers/resolver';
 import {
   setResolver
 } from 'ember-qunit';
+import QUnit from 'qunit';
 
 setResolver(resolver);
+
+QUnit.config.testTimeout = 5000;


### PR DESCRIPTION
Ember Acceptance Tests wait for all scheduled run loops to finish before proceeding. See [documentation](https://guides.emberjs.com/v2.7.0/applications/run-loop/#toc_how-is-run-loop-behaviour-different-when-testing).

`mixin:triggers-change` is fundamentally incompatible with this paradigm because it schedules run loops in perpetuity.

This fix disables `mixin:triggers-change` by default in test mode so that it does not interfere with tests in applications that use this addon.